### PR TITLE
handle Koa failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![banner](./public/img/banner-paddings.png)
 
-[![Build Status](https://github.com/vrsandeep/Mango/actions/workflows/dockerhub.yml/badge.svg)](https://github.com/vrsandeep/Mango/actions?query=workflow%3Adockerhub+event%3Apush+branch%3Amaster)
+[![Build Status](https://github.com/vrsandeep/Mango/actions/workflows/dockerhub.yml/badge.svg)](https://github.com/vrsandeep/Mango/actions/workflows/dockerhub.yml?query=event%3Arelease)
 
 # Notes
 

--- a/public/js/subscription-manager.js
+++ b/public/js/subscription-manager.js
@@ -15,7 +15,9 @@ const component = () => {
 
           let pid = localStorage.getItem('plugin');
           if (!pid || !this.plugins.find((p) => p.id === pid)) {
-            pid = this.plugins[0].id;
+            if (this.plugins.length > 0) {
+              pid = this.plugins[0].id;
+            }
           }
 
           this.pid = pid;

--- a/src/mango.cr
+++ b/src/mango.cr
@@ -65,8 +65,10 @@ class CLI < Clim
 
       spawn do
         begin
+          Logger.debug "Starting Mango Server..."
           Server.new.start
         rescue e
+          Logger.error "An error occurred while starting the server."
           Logger.fatal e
           Process.exit 1
         end

--- a/src/routes/api.cr
+++ b/src/routes/api.cr
@@ -64,7 +64,7 @@ struct APIRouter
     Koa.schema "filter", {
       "key"   => String,
       "type"  => String,
-      "value" => String | Int32 | Int64 | Float32,
+      "value" => String, # | Int32 | Int64 | Float32,
     }
 
     Koa.schema "subscription", {

--- a/src/views/subscription-manager.html.ecr
+++ b/src/views/subscription-manager.html.ecr
@@ -1,8 +1,8 @@
-<h2 class=uk-title>Subscription Manager</h2>
+<h2 class="uk-title uk-text-center">Subscription Manager</h2>
 <div x-data="component()" x-init="init()">
   <div class="uk-grid-small" uk-grid style="margin-bottom:40px;">
     <div class="uk-container uk-text-center" x-show="plugins.length === 0" style="width:100%">
-      <h2>No Plugins Found</h2>
+      <h3>No Plugins Found</h2>
       <p>We could't find any plugins in the directory <code><%= Config.current.plugin_path %></code>.</p>
       <p>You can download official plugins from the <a href="https://github.com/hkalexling/mango-plugins">Mango plugins repository</a>.</p>
     </div>


### PR DESCRIPTION
Koa was failing when the schema is a `Union` of types.

I couldn't figure out how to fix Koa library, so instead placed a hack.

This PR also fixes the `Logger` class, where `#fatal`, `#warn`... were not printing anything to console.