### PR TITLE
upgrade crystal to 1.16.3

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
     if: "!contains(github.event.head_commit.message, 'skip ci')"
     runs-on: ubuntu-latest
     container:
-      image: crystallang/crystal:1.14.0-alpine
+      image: crystallang/crystal:1.16.3-alpine
 
     steps:
     - uses: actions/checkout@v4

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM crystallang/crystal:1.14.0-alpine AS builder
+FROM crystallang/crystal:1.16.3-alpine AS builder
 
 WORKDIR /Mango
 

--- a/Dockerfile.arm32v7
+++ b/Dockerfile.arm32v7
@@ -2,14 +2,14 @@ FROM arm32v7/ubuntu:18.04
 
 RUN apt-get update && apt-get install -y wget git make llvm-8 llvm-8-dev g++ libsqlite3-dev libyaml-dev libgc-dev libssl-dev libcrypto++-dev libevent-dev libgmp-dev zlib1g-dev libpcre++-dev pkg-config libarchive-dev libxml2-dev libacl1-dev nettle-dev liblzo2-dev liblzma-dev libbz2-dev libjpeg-turbo8-dev libpng-dev libtiff-dev cmake
 
-RUN git clone https://github.com/crystal-lang/crystal && cd crystal && git checkout 1.0.0 && make deps && cd ..
-RUN git clone https://github.com/kostya/myhtml && cd myhtml/src/ext && git checkout v1.5.8 && make && cd ..
-RUN git clone https://github.com/jessedoyle/duktape.cr && cd duktape.cr/ext && git checkout v1.0.0 && make && cd ..
-RUN git clone https://github.com/hkalexling/image_size.cr && cd image_size.cr && git checkout v0.5.0 && make && cd ..
+RUN git clone https://github.com/crystal-lang/crystal && cd crystal && git checkout 1.16.3 && make deps && cd ..
+RUN git clone https://github.com/kostya/lexbor && cd lexbor/src/ext && git checkout v3.3.2 && make && cd ..
+RUN git clone https://github.com/jessedoyle/duktape.cr && cd duktape.cr/ext && git checkout v1.1.0 && make && cd ..
+RUN git clone https://github.com/n-pn/image_size.cr && cd image_size.cr && git reset --hard de5542313b6ad5f8769f30936eb7de68829c87b1 && make && cd ..
 
 COPY mango-arm32v7.o .
 
-RUN cc 'mango-arm32v7.o' -o '/usr/local/bin/mango' -rdynamic -lxml2 -L/image_size.cr/ext/libwebp -lwebp -L/image_size.cr/ext/stbi -lstbi /lexbor/src/ext/lexbor-c/build/liblexbor_static.a -L/duktape.cr/src/.build/lib -L/duktape.cr/src/.build/include -lduktape -lm `pkg-config libarchive --libs` -lz `command -v pkg-config > /dev/null && pkg-config --libs --silence-errors libssl || printf %s '-lssl -lcrypto'` `command -v pkg-config > /dev/null && pkg-config --libs --silence-errors libcrypto || printf %s '-lcrypto'` -lgmp -lsqlite3 -lyaml -lpcre -lm /usr/lib/arm-linux-gnueabihf/libgc.so -lpthread /crystal/src/ext/libcrystal.a -levent -lrt -ldl -L/usr/bin/../lib/crystal/lib -L/usr/bin/../lib/crystal/lib
+RUN cc 'mango-arm32v7.o' -o '/usr/local/bin/mango' -rdynamic -static -L/usr/bin/../lib/crystal /lexbor/src/lexbor/../ext/lexbor-c/build/liblexbor_static.a -L/duktape/src/.build/lib -L/duktape/src/.build/include -lduktape -lm -lxml2 -lm -L/lib -lz -llzma -pthread -lpthread `pkg-config libarchive --libs --static` -L/image_size/src/../ext/libwebp/ -lwebp -L/image_size/src/../ext/stbi/ -lstbi -lz `command -v pkg-config > /dev/null && pkg-config --libs --silence-errors libssl || printf %s '-lssl -lcrypto'` `command -v pkg-config > /dev/null && pkg-config --libs --silence-errors libcrypto || printf %s '-lcrypto'` -lgmp -lsqlite3 -lyaml -lpcre2-8 -lm -lgc -lpthread -ldl -lpthread -lpthread -ldl
 
 CMD ["/usr/local/bin/mango"]
 

--- a/Dockerfile.arm32v7
+++ b/Dockerfile.arm32v7
@@ -9,7 +9,7 @@ RUN git clone https://github.com/hkalexling/image_size.cr && cd image_size.cr &&
 
 COPY mango-arm32v7.o .
 
-RUN cc 'mango-arm32v7.o' -o '/usr/local/bin/mango' -rdynamic -lxml2 -L/image_size.cr/ext/libwebp -lwebp -L/image_size.cr/ext/stbi -lstbi /myhtml/src/ext/modest-c/lib/libmodest_static.a -L/duktape.cr/src/.build/lib -L/duktape.cr/src/.build/include -lduktape -lm `pkg-config libarchive --libs` -lz `command -v pkg-config > /dev/null && pkg-config --libs --silence-errors libssl || printf %s '-lssl -lcrypto'` `command -v pkg-config > /dev/null && pkg-config --libs --silence-errors libcrypto || printf %s '-lcrypto'` -lgmp -lsqlite3 -lyaml -lpcre -lm /usr/lib/arm-linux-gnueabihf/libgc.so -lpthread /crystal/src/ext/libcrystal.a -levent -lrt -ldl -L/usr/bin/../lib/crystal/lib -L/usr/bin/../lib/crystal/lib
+RUN cc 'mango-arm32v7.o' -o '/usr/local/bin/mango' -rdynamic -lxml2 -L/image_size.cr/ext/libwebp -lwebp -L/image_size.cr/ext/stbi -lstbi /lexbor/src/ext/lexbor-c/build/liblexbor_static.a -L/duktape.cr/src/.build/lib -L/duktape.cr/src/.build/include -lduktape -lm `pkg-config libarchive --libs` -lz `command -v pkg-config > /dev/null && pkg-config --libs --silence-errors libssl || printf %s '-lssl -lcrypto'` `command -v pkg-config > /dev/null && pkg-config --libs --silence-errors libcrypto || printf %s '-lcrypto'` -lgmp -lsqlite3 -lyaml -lpcre -lm /usr/lib/arm-linux-gnueabihf/libgc.so -lpthread /crystal/src/ext/libcrystal.a -levent -lrt -ldl -L/usr/bin/../lib/crystal/lib -L/usr/bin/../lib/crystal/lib
 
 CMD ["/usr/local/bin/mango"]
 

--- a/Dockerfile.arm64v8
+++ b/Dockerfile.arm64v8
@@ -2,13 +2,13 @@ FROM arm64v8/ubuntu:24.04
 
 RUN apt-get update && apt-get install -y wget git make llvm-8 llvm-8-dev g++ libsqlite3-dev libyaml-dev libgc-dev libssl-dev libcrypto++-dev libevent-dev libgmp-dev zlib1g-dev libpcre++-dev pkg-config libarchive-dev libxml2-dev libacl1-dev nettle-dev liblzo2-dev liblzma-dev libbz2-dev libjpeg-turbo8-dev libpng-dev libtiff-dev cmake
 
-RUN git clone https://github.com/crystal-lang/crystal && cd crystal && git checkout 1.14.0 && make deps && cd ..
+RUN git clone https://github.com/crystal-lang/crystal && cd crystal && git checkout 1.16.3 && make deps && cd ..
 RUN git clone https://github.com/kostya/myhtml && cd myhtml/src/ext && git checkout v1.5.8 && make && cd ..
 RUN git clone https://github.com/jessedoyle/duktape.cr && cd duktape.cr/ext && git checkout v1.0.0 && make && cd ..
 RUN git clone https://github.com/hkalexling/image_size.cr && cd image_size.cr && git checkout v0.5.0 && make && cd ..
 
 COPY mango-arm64v8.o .
 
-RUN cc 'mango-arm64v8.o' -o '/usr/local/bin/mango' -rdynamic -lxml2 -L/image_size.cr/ext/libwebp -lwebp -L/image_size.cr/ext/stbi -lstbi /myhtml/src/ext/modest-c/lib/libmodest_static.a -L/duktape.cr/src/.build/lib -L/duktape.cr/src/.build/include -lduktape -lm `pkg-config libarchive --libs` -lz `command -v pkg-config > /dev/null && pkg-config --libs --silence-errors libssl || printf %s '-lssl -lcrypto'` `command -v pkg-config > /dev/null && pkg-config --libs --silence-errors libcrypto || printf %s '-lcrypto'` -lgmp -lsqlite3 -lyaml -lpcre -lm /usr/lib/aarch64-linux-gnu/libgc.so -lpthread /crystal/src/ext/libcrystal.a -levent -lrt -ldl -L/usr/bin/../lib/crystal/lib -L/usr/bin/../lib/crystal/lib
+RUN cc 'mango-arm64v8.o' -o '/usr/local/bin/mango' -rdynamic -lxml2 -L/image_size.cr/ext/libwebp -lwebp -L/image_size.cr/ext/stbi -lstbi /lexbor/src/ext/lexbor-c/build/liblexbor_static.a -L/duktape.cr/src/.build/lib -L/duktape.cr/src/.build/include -lduktape -lm `pkg-config libarchive --libs` -lz `command -v pkg-config > /dev/null && pkg-config --libs --silence-errors libssl || printf %s '-lssl -lcrypto'` `command -v pkg-config > /dev/null && pkg-config --libs --silence-errors libcrypto || printf %s '-lcrypto'` -lgmp -lsqlite3 -lyaml -lpcre -lm /usr/lib/aarch64-linux-gnu/libgc.so -lpthread /crystal/src/ext/libcrystal.a -levent -lrt -ldl -L/usr/bin/../lib/crystal/lib -L/usr/bin/../lib/crystal/lib
 
 CMD ["/usr/local/bin/mango"]

--- a/Dockerfile.arm64v8
+++ b/Dockerfile.arm64v8
@@ -3,12 +3,12 @@ FROM arm64v8/ubuntu:24.04
 RUN apt-get update && apt-get install -y wget git make llvm-8 llvm-8-dev g++ libsqlite3-dev libyaml-dev libgc-dev libssl-dev libcrypto++-dev libevent-dev libgmp-dev zlib1g-dev libpcre++-dev pkg-config libarchive-dev libxml2-dev libacl1-dev nettle-dev liblzo2-dev liblzma-dev libbz2-dev libjpeg-turbo8-dev libpng-dev libtiff-dev cmake
 
 RUN git clone https://github.com/crystal-lang/crystal && cd crystal && git checkout 1.16.3 && make deps && cd ..
-RUN git clone https://github.com/kostya/myhtml && cd myhtml/src/ext && git checkout v1.5.8 && make && cd ..
-RUN git clone https://github.com/jessedoyle/duktape.cr && cd duktape.cr/ext && git checkout v1.0.0 && make && cd ..
-RUN git clone https://github.com/hkalexling/image_size.cr && cd image_size.cr && git checkout v0.5.0 && make && cd ..
+RUN git clone https://github.com/kostya/lexbor && cd lexbor/src/ext && git checkout v3.3.2 && make && cd ..
+RUN git clone https://github.com/jessedoyle/duktape.cr && cd duktape.cr/ext && git checkout v1.1.0 && make && cd ..
+RUN git clone https://github.com/n-pn/image_size.cr && cd image_size.cr && git reset --hard de5542313b6ad5f8769f30936eb7de68829c87b1 && make && cd ..
 
 COPY mango-arm64v8.o .
 
-RUN cc 'mango-arm64v8.o' -o '/usr/local/bin/mango' -rdynamic -lxml2 -L/image_size.cr/ext/libwebp -lwebp -L/image_size.cr/ext/stbi -lstbi /lexbor/src/ext/lexbor-c/build/liblexbor_static.a -L/duktape.cr/src/.build/lib -L/duktape.cr/src/.build/include -lduktape -lm `pkg-config libarchive --libs` -lz `command -v pkg-config > /dev/null && pkg-config --libs --silence-errors libssl || printf %s '-lssl -lcrypto'` `command -v pkg-config > /dev/null && pkg-config --libs --silence-errors libcrypto || printf %s '-lcrypto'` -lgmp -lsqlite3 -lyaml -lpcre -lm /usr/lib/aarch64-linux-gnu/libgc.so -lpthread /crystal/src/ext/libcrystal.a -levent -lrt -ldl -L/usr/bin/../lib/crystal/lib -L/usr/bin/../lib/crystal/lib
+RUN cc 'mango-arm64v8.o' -o '/usr/local/bin/mango' -rdynamic -static -L/usr/bin/../lib/crystal /lexbor/src/lexbor/../ext/lexbor-c/build/liblexbor_static.a -L/duktape/src/.build/lib -L/duktape/src/.build/include -lduktape -lm -lxml2 -lm -L/lib -lz -llzma -pthread -lpthread `pkg-config libarchive --libs --static` -L/image_size/src/../ext/libwebp/ -lwebp -L/image_size/src/../ext/stbi/ -lstbi -lz `command -v pkg-config > /dev/null && pkg-config --libs --silence-errors libssl || printf %s '-lssl -lcrypto'` `command -v pkg-config > /dev/null && pkg-config --libs --silence-errors libcrypto || printf %s '-lcrypto'` -lgmp -lsqlite3 -lyaml -lpcre2-8 -lm -lgc -lpthread -ldl -lpthread -lpthread -ldl
 
 CMD ["/usr/local/bin/mango"]

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ static: uglify | libs
 	crystal build src/mango.cr --release --progress --static --error-trace
 
 libs:
-	shards install --production
+	shards install
 
 run:
 	crystal run src/mango.cr --error-trace

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ The official docker images are available on [Dockerhub](https://hub.docker.com/r
 
 1. If you are running MacOS, make sure to specify platform `--platform linux/amd64` to `docker run`
 ```shell
-docker run --platform linux/amd64 --rm -ti -v $PWD:/mango crystallang/crystal:1.14.0-alpine sh
+docker run --platform linux/amd64 --rm -ti -v $PWD:/mango crystallang/crystal:1.16.3-alpine sh
 ```
 2. `cd mango`  inside the container.
 3. Checkout [build.yml](./.github/workflows/build.yml) for complete steps.

--- a/shard.lock
+++ b/shard.lock
@@ -54,7 +54,7 @@ shards:
 
   lexbor:
     git: https://github.com/kostya/lexbor.git
-    version: 3.2.0
+    version: 3.3.2
 
   mg:
     git: https://github.com/vrsandeep/mg.git

--- a/shard.lock
+++ b/shard.lock
@@ -10,7 +10,7 @@ shards:
 
   backtracer:
     git: https://github.com/sija/backtracer.cr.git
-    version: 1.2.2
+    version: 1.2.4
 
   baked_file_system:
     git: https://github.com/schovi/baked_file_system.git
@@ -34,11 +34,11 @@ shards:
 
   http_proxy:
     git: https://github.com/mamantoha/http_proxy.git
-    version: 0.12.1
+    version: 0.13.0
 
   image_size:
-    git: https://github.com/akkoyk/image_size.cr.git
-    version: 0.5.0
+    git: https://github.com/by6756/image_size.cr.git
+    version: 0.5.0+git.commit.83c0122bfac1f64733f718cc0febd72d34d4d7bc
 
   kemal:
     git: https://github.com/kemalcr/kemal.git
@@ -69,8 +69,8 @@ shards:
     version: 0.4.1
 
   sanitize:
-    git: https://github.com/hkalexling/sanitize.git
-    version: 0.1.0+git.commit.e09520e972d0d9b70b71bb003e6831f7c2c59dce
+    git: https://github.com/straight-shoota/sanitize.git
+    version: 0.1.0+git.commit.c17d933fed22c6d3d615cca91a895166414389af
 
   sqlite3:
     git: https://github.com/crystal-lang/crystal-sqlite3.git

--- a/shard.lock
+++ b/shard.lock
@@ -37,8 +37,8 @@ shards:
     version: 0.13.0
 
   image_size:
-    git: https://github.com/by6756/image_size.cr.git
-    version: 0.5.0+git.commit.83c0122bfac1f64733f718cc0febd72d34d4d7bc
+    git: https://github.com/n-pn/image_size.cr.git
+    version: 0.5.1+git.commit.de5542313b6ad5f8769f30936eb7de68829c87b1
 
   kemal:
     git: https://github.com/kemalcr/kemal.git

--- a/shard.yml
+++ b/shard.yml
@@ -39,7 +39,7 @@ dependencies:
     version: 1.1.0
   lexbor:
     github: kostya/lexbor
-    version: 3.2.0
+    version: 3.3.2
   http_proxy:
     github: mamantoha/http_proxy
     version: 0.13.0

--- a/shard.yml
+++ b/shard.yml
@@ -44,7 +44,7 @@ dependencies:
     github: mamantoha/http_proxy
     version: 0.13.0
   image_size:
-   github: by6756/image_size.cr
+   github: n-pn/image_size.cr
   koa:
     github: hkalexling/koa
     version: 0.9.0

--- a/shard.yml
+++ b/shard.yml
@@ -42,10 +42,9 @@ dependencies:
     version: 3.2.0
   http_proxy:
     github: mamantoha/http_proxy
-    version: 0.12.1
+    version: 0.13.0
   image_size:
-   github: akkoyk/image_size.cr
-   version: 0.5.0
+   github: by6756/image_size.cr
   koa:
     github: hkalexling/koa
     version: 0.9.0
@@ -55,4 +54,4 @@ dependencies:
   mg:
     github: vrsandeep/mg
   sanitize:
-    github: hkalexling/sanitize
+    github: straight-shoota/sanitize

--- a/src/library/entry.cr
+++ b/src/library/entry.cr
@@ -18,7 +18,7 @@ abstract class Entry
   def initialize(
     @id, @title, @book, @path,
     @size, @pages, @mtime,
-    @encoded_path, @encoded_title, @err_msg
+    @encoded_path, @encoded_title, @err_msg,
   )
   end
 

--- a/src/util/chapter_sort.cr
+++ b/src/util/chapter_sort.cr
@@ -55,7 +55,7 @@ class ChapterSorter
   @sorted_keys = [] of String
 
   def has_key_with_variation?(
-    key : String, available_keys : Array(String)
+    key : String, available_keys : Array(String),
   ) : String | Nil
     # using available_keys {} of String => KeyRange, check if the key
     # exists as a variant of an existing key in available_keys.
@@ -112,7 +112,7 @@ class ChapterSorter
   end
 
   def merge_repeated_key_ranges(
-    top_keys : Array(String), key_ranges : Hash(String, KeyRange)
+    top_keys : Array(String), key_ranges : Hash(String, KeyRange),
   ) : Nil
     # For keys not belonging to top_keys, check if the key is a
     # variant of one of the top keys. If it is, merge the key ranges


### PR DESCRIPTION
1. Also upgrades libraries
2. Fix Dockerfiles of arm64 and 32. This was done by simply running `make arm32v7`, `make arm64v8`. The crystal compiler then prints the command to run on the respective system as pointed out in the docs: https://crystal-lang.org/reference/1.16/syntax_and_semantics/cross-compilation.html