### PR TITLE
fix multiple redirects due to pagination from reader

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ The original repo at https://github.com/getmango/Mango has stopped accepting new
 
 This repo will try to bring in some updates to keep the project alive for a little while longer. You can use the new docker image based on the code here at `vrsandeep/mango:latest`. The configuration and everything else is same as `hkalexling/mango` and is as follows
 
+For new feature developments, switchover to https://github.com/vrsandeep/Mango-go, a completely re-written fork of this project.
+
 # Mango
 
 [![Discord](https://img.shields.io/discord/855633663425118228?label=discord)](http://discord.com/invite/ezKtacCp9Q)

--- a/public/js/reader.js
+++ b/public/js/reader.js
@@ -15,6 +15,7 @@ const readerComponent = () => {
     preloadLookahead: 3,
     enableRightToLeft: false,
     fitType: 'vert',
+    page_size: 100,
 
     /**
      * Initialize the component by fetching the page dimensions
@@ -45,6 +46,7 @@ const readerComponent = () => {
           this.longPages = avgRatio > 2;
           this.loading = false;
           this.mode = localStorage.getItem('mode') || 'continuous';
+          this.page_size = localStorage.getItem('page_size') || 100;
 
           // Here we save a copy of this.mode, and use the copy as
           // 	the model-select value. This is because `updateMode`
@@ -333,7 +335,7 @@ const readerComponent = () => {
      */
     exitReader(exitUrl) {
       this.saveProgress(this.items.length, () => {
-        this.redirect(exitUrl);
+        this.redirect(exitUrl + '?page_size=' + this.page_size);
       });
     },
 

--- a/shard.lock
+++ b/shard.lock
@@ -14,7 +14,7 @@ shards:
 
   baked_file_system:
     git: https://github.com/schovi/baked_file_system.git
-    version: 0.10.0
+    version: 0.11.0
 
   clim:
     git: https://github.com/at-grandpa/clim.git
@@ -22,7 +22,7 @@ shards:
 
   db:
     git: https://github.com/crystal-lang/crystal-db.git
-    version: 0.13.1
+    version: 0.14.0
 
   duktape:
     git: https://github.com/jessedoyle/duktape.cr.git
@@ -30,7 +30,7 @@ shards:
 
   exception_page:
     git: https://github.com/crystal-loot/exception_page.git
-    version: 0.4.1
+    version: 0.5.0
 
   http_proxy:
     git: https://github.com/mamantoha/http_proxy.git
@@ -42,11 +42,11 @@ shards:
 
   kemal:
     git: https://github.com/kemalcr/kemal.git
-    version: 1.6.0
+    version: 1.7.2
 
   kemal-session:
     git: https://github.com/kemalcr/kemal-session.git
-    version: 1.0.0
+    version: 1.3.0
 
   koa:
     git: https://github.com/hkalexling/koa.git
@@ -74,7 +74,7 @@ shards:
 
   sqlite3:
     git: https://github.com/crystal-lang/crystal-sqlite3.git
-    version: 0.21.0
+    version: 0.22.0
 
   tallboy:
     git: https://github.com/epoch/tallboy.git

--- a/shard.yml
+++ b/shard.yml
@@ -15,16 +15,16 @@ license: MIT
 dependencies:
   kemal:
     github: kemalcr/kemal
-    version: 1.6.0
+    version: 1.7.2
   kemal-session:
     github: kemalcr/kemal-session
-    version: 1.0.0
+    version: 1.3.0
   sqlite3:
     github: crystal-lang/crystal-sqlite3
-    version: 0.21.0
+    version: 0.22.0
   baked_file_system:
     github: schovi/baked_file_system
-    version: 0.10.0
+    version: 0.11.0
   archive:
     github: vrsandeep/archive.cr
     version: 0.6.0

--- a/src/views/library.html.ecr
+++ b/src/views/library.html.ecr
@@ -5,6 +5,7 @@
   <div class="uk-form-horizontal uk-margin-remove-vertical uk-flex uk-flex-middle">
     <label for="page-size-select" style="width:70px;" class="uk-form-label uk-text-small">Per page:</label>
     <select class="uk-select uk-width-auto" id="page-size-select" onchange="changePageSize(this.value)">
+      <option value="5">5</option>
       <option value="25">25</option>
       <option value="50">50</option>
       <option value="100">100</option>

--- a/src/views/reader-error.html.ecr
+++ b/src/views/reader-error.html.ecr
@@ -13,7 +13,7 @@
       <% if next_entry = entry.next_entry username %>
         <a class="uk-button uk-button-default" href="<%= base_url %>reader/<%= entry.book.id %>/<%= next_entry.id %>">Next Entry</a>
       <% end %>
-      <a class="uk-button uk-button-primary" href="<%= base_url %>book/<%= entry.book.id %>">Return to Title</a>
+      <a id="return-to-title-btn" class="uk-button uk-button-primary" href="<%= base_url %>book/<%= entry.book.id %>">Return to Title</a>
       </p>
     </div>
   </div>
@@ -21,9 +21,12 @@
 
 <% content_for "script" do %>
   <script>
+    const page_size = localStorage.getItem('page_size') || "100";
     UIkit.modal('#modal').show();
     UIkit.util.on('#modal', 'hide', function() {
-      location.href = "<%= base_url %>book/<%= entry.book.id %>";
+location.href = "<%= base_url %>book/<%= entry.book.id %>" + "?page_size=" + page_size
+      });
     });
+    document.getElementById('return-to-title-btn').href += "?page_size=" + page_size;
   </script>
 <% end %>

--- a/src/views/reader.html.ecr
+++ b/src/views/reader.html.ecr
@@ -43,12 +43,12 @@
         <div x-cloak x-show="!loading && mode !== 'continuous'" class="uk-flex uk-flex-middle" :style="`height:${fitType === 'vert' ? '100vh' : ''}; min-width: fit-content;`">
 
           <img uk-img :class="{
-                               'uk-align-center': true, 
-                               'uk-animation-slide-left': flipAnimation === 'left', 
+                               'uk-align-center': true,
+                               'uk-animation-slide-left': flipAnimation === 'left',
                                'uk-animation-slide-right': flipAnimation === 'right'
                                }" :data-src="curItem.url" :width="curItem.width" :height="curItem.height" :id="curItem.id" @click="clickImage($event)" :style="`
-                                                                                                                                                                 width:${fitType === 'horz' ? '100vw' : 'auto'}; 
-                                                                                                                                                                 height:${fitType === 'vert' ? '100vh' : 'auto'}; 
+                                                                                                                                                                 width:${fitType === 'horz' ? '100vw' : 'auto'};
+                                                                                                                                                                 height:${fitType === 'vert' ? '100vh' : 'auto'};
                                                                                                                                                                  margin-bottom:0;
                                                                                                                                                                  max-width:${fitType === 'horz' ? '100%' : fitType === 'vert' ? '' : 'none' };
                                                                                                                                                                  max-height:${fitType === 'vert' ? '100%' : fitType === 'horz' ? '' : 'none'};
@@ -156,16 +156,21 @@
           <% if next_entry_url %>
             <a class="uk-button uk-button-default uk-margin-small-bottom uk-margin-small-right" href="<%= next_entry_url %>">Next Entry</a>
           <% end %>
-          <a class="uk-button uk-button-danger uk-margin-small-bottom uk-margin-small-right" href="<%= exit_url %>">Exit Reader</a>
+          <a id="exit-btn" class="uk-button uk-button-danger uk-margin-small-bottom uk-margin-small-right" href="<%= exit_url %>">Exit Reader</a>
         </div>
       </div>
     </div>
 
-    <script>
+    <script type="text/javascript">
       const base_url = "<%= base_url %>";
       const page = <%= page_idx %>;
       const tid = "<%= title.id %>";
       const eid = "<%= entry.id %>";
+      const page_size = localStorage.getItem('page_size') || "100";
+const exit_url = "<%= exit_url %>" + "?page_size=" + page_size
+
+      const ext_modal_link = document.getElementById('exit-btn');
+      ext_modal_link.href = exit_url;
     </script>
     <script src="<%= base_url %>ext/js/jquery.inview-1.1.2.min.js"></script>
     <%= render_component "uikit" %>

--- a/src/views/title.html.ecr
+++ b/src/views/title.html.ecr
@@ -39,6 +39,7 @@
   <div class="uk-form-horizontal uk-margin-remove-vertical uk-flex uk-flex-middle">
     <label for="page-size-select" style="width:70px;" class="uk-form-label uk-text-small">Per page:</label>
     <select class="uk-select uk-width-auto" id="page-size-select" onchange="changePageSize(this.value)">
+      <option value="5">5</option>
       <option value="25">25</option>
       <option value="50">50</option>
       <option value="100">100</option>


### PR DESCRIPTION
Clicking Exit reader button would redirect to the library, but it would not retain the page size parameter. On page load of the book, it would reload with a page size parameter.

## This PR 

1. Avoids the two page loads by passing page_size parameter on button click.
2. Updates underlying packages
3. Adds link to the new project re-written from ground up